### PR TITLE
CVSL-2157 centralising static path routes 

### DIFF
--- a/server/routes/caseAdmin/index.ts
+++ b/server/routes/caseAdmin/index.ts
@@ -1,5 +1,5 @@
 import { RequestHandler, Router } from 'express'
-import { path } from 'static-path'
+import { Path } from 'static-path'
 import asyncMiddleware from '../../middleware/asyncMiddleware'
 import roleCheckMiddleware from '../../middleware/roleCheckMiddleware'
 import AuthRole from '../../enumeration/authRole'
@@ -7,27 +7,22 @@ import CaseloadRoutes from './caseload'
 import { Services } from '../../services'
 import AssessmentRoutes from './assessment'
 import TasklistRoutes from './initialChecks/tasklist'
+import paths from '../paths'
 
 export default function Index({ caseAdminCaseloadService }: Services): Router {
   const router = Router()
-  const prison = path('/prison')
-  const caseload = prison.path('caseload')
-  const assessment = prison.path('assessment/:prisonNumber')
-  const initialChecks = assessment.path('initial-checks')
 
-  const get = (routerPath: string, handler: RequestHandler) =>
-    router.get(routerPath, roleCheckMiddleware([AuthRole.CASE_ADMIN]), asyncMiddleware(handler))
+  const get = <T extends string>(routerPath: Path<T>, handler: RequestHandler) =>
+    router.get(routerPath.pattern, roleCheckMiddleware([AuthRole.CASE_ADMIN]), asyncMiddleware(handler))
 
   const supportHomeHandler = new CaseloadRoutes(caseAdminCaseloadService)
-
-  get(caseload.pattern, supportHomeHandler.GET)
+  get(paths.prison.caseload, supportHomeHandler.GET)
 
   const assessmentHandler = new AssessmentRoutes(caseAdminCaseloadService)
-
-  get(assessment.pattern, assessmentHandler.GET)
+  get(paths.prison.assessment.home, assessmentHandler.GET)
 
   const tasklistRoutes = new TasklistRoutes(caseAdminCaseloadService)
-  get(initialChecks.pattern, tasklistRoutes.GET)
+  get(paths.prison.assessment.initialChecks, tasklistRoutes.GET)
 
   return router
 }

--- a/server/routes/paths.ts
+++ b/server/routes/paths.ts
@@ -1,0 +1,24 @@
+import { path } from 'static-path'
+
+const supportHome = path('/support')
+const prison = path('/prison')
+
+const caseload = prison.path('caseload')
+const assessmentHome = prison.path('assessment/:prisonNumber')
+
+const initialChecks = assessmentHome.path('initial-checks')
+
+const paths = {
+  support: {
+    home: supportHome,
+  },
+  prison: {
+    caseload,
+    assessment: {
+      home: assessmentHome,
+      initialChecks,
+    },
+  },
+}
+
+export default paths

--- a/server/routes/support/index.ts
+++ b/server/routes/support/index.ts
@@ -1,20 +1,20 @@
 import { RequestHandler, Router } from 'express'
-import { path } from 'static-path'
+import { Path } from 'static-path'
 import asyncMiddleware from '../../middleware/asyncMiddleware'
 import roleCheckMiddleware from '../../middleware/roleCheckMiddleware'
 import SupportHomeRoutes from './handlers/supportHome'
 import AuthRole from '../../enumeration/authRole'
+import paths from '../paths'
 
 export default function Index(): Router {
   const router = Router()
-  const support = path('/support')
 
-  const get = (routerPath: string, handler: RequestHandler) =>
-    router.get(routerPath, roleCheckMiddleware([AuthRole.SUPPORT]), asyncMiddleware(handler))
+  const get = <T extends string>(routerPath: Path<T>, handler: RequestHandler) =>
+    router.get(routerPath.pattern, roleCheckMiddleware([AuthRole.SUPPORT]), asyncMiddleware(handler))
 
   const supportHomeHandler = new SupportHomeRoutes()
 
-  get(support({}), supportHomeHandler.GET)
+  get(paths.support.home, supportHomeHandler.GET)
 
   return router
 }

--- a/server/utils/nunjucksSetup.test.ts
+++ b/server/utils/nunjucksSetup.test.ts
@@ -1,0 +1,40 @@
+import nunjucks from 'nunjucks'
+import { registerNunjucks } from './nunjucksSetup'
+
+describe('nunjucksSetup', () => {
+  const renderTemplate = (template: string, model: Record<string, unknown>) => {
+    const njkEnv = registerNunjucks()
+    const compiledTemplate = nunjucks.compile(template, njkEnv)
+    return compiledTemplate.render(model)
+  }
+
+  describe('toPath', () => {
+    test('with correct args:', () => {
+      const result = renderTemplate(
+        ' {{- paths.prison.assessment.initialChecks | toPath({prisonNumber: "A1224"}) -}} ',
+        {},
+      )
+      expect(result).toStrictEqual('/prison/assessment/A1224/initial-checks')
+    })
+
+    test('with incorrect args:', () => {
+      try {
+        renderTemplate(' {{- paths.prison.assessment.initialChecks | toPath({prisonNUMBER: "A1224"}) -}} ', {})
+        expect(true).toBe(false)
+      } catch (e) {
+        expect(e.message).toContain(
+          `the path param "prisonNumber" didn't exist on params object {"prisonNUMBER":"A1224"}`,
+        )
+      }
+    })
+
+    test('invalid path:', () => {
+      try {
+        renderTemplate(' {{- paths.prison.assessment.aaaaaa | toPath({prisonNumber: "A1224"}) -}} ', {})
+        expect(true).toBe(false)
+      } catch (e) {
+        expect(e.message).toContain(`Error: no path provided`)
+      }
+    })
+  })
+})

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -3,10 +3,12 @@ import path from 'path'
 import nunjucks, { Environment } from 'nunjucks'
 import express from 'express'
 import fs from 'fs'
+import { Params, Path } from 'static-path'
 import { initialiseName, toIsoDate } from './utils'
 import config from '../config'
 import logger from '../../logger'
 import { ApplicationInfo } from '../applicationInfo'
+import paths from '../routes/paths'
 
 const production = process.env.NODE_ENV === 'production'
 
@@ -65,6 +67,13 @@ export function registerNunjucks(app?: express.Express): Environment {
     'dumpJson',
     (val: string) => new nunjucks.runtime.SafeString(`<pre>${JSON.stringify(val, null, 2)}</pre>`),
   )
+  njkEnv.addGlobal('paths', paths)
+  njkEnv.addFilter('toPath', <T extends string>(staticPath: Path<T>, params: Params<T>) => {
+    if (!staticPath) {
+      throw Error(`no path provided`)
+    }
+    return staticPath(params)
+  })
 
   return njkEnv
 }

--- a/server/views/pages/index.njk
+++ b/server/views/pages/index.njk
@@ -1,10 +1,9 @@
 {% extends "layout.njk" %}
 {% from "partials/card.njk" import card %}
 
+{% set bodyAttributes = { "data-page": "home" } %}
 {% set pageTitle = applicationName + " - Home" %}
 {% set mainClasses = "app-container govuk-body" %}
-
-{% set bodyAttributes = { "data-page": "home" } %}
 
 {% block content %}
     <div class="grid-row">


### PR DESCRIPTION
Also added a nunjucks filter for making use of paths:
```
 {{ paths.prison.assessment.initialChecks | build({prisonNumber: 'A1224'}) }}
```
->  `/prison/assessment/A1224/initial-checks`

It will fail if non-existent path is passed or the correct args aren't passed 