### PR TITLE
CVSL-2399 enabling scheduled downtime

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -20,5 +20,8 @@ generic-service:
     # Needs to be updated
     PHASE_BANNER_LINK: 'https://assess-for-early-release-dev.hmpps.service.justice.gov.uk'
 
+  scheduledDowntime:
+    enabled: true
+
 generic-prometheus-alerts:
   alertSeverity: 


### PR DESCRIPTION
This will shut down pods between 10pm - 6:30am UTC on weekdays and all day on weekends. 6:30am was chosen as the RDS startup happens between 6am and 6:30am.