### PR TITLE
CVSL-2723 make frontend changes to accommodate changes from the backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Then run the server in test mode by:
 
 `npm run start-feature` (or `npm run start-feature:dev` to run with auto-restart on changes)
 
+If there is an error with Node, try use `nvm use` which will ensure you are using the version of Node specified in the `.nvmrc` file
+
 <em>The server should startup normally and you should see something like this in the logs:</em>
 
 `14:26:46.498Z INFO Hmpps Assess For Early Release Ui: Server listening on port 3007`

--- a/integration_tests/mockApis/assessForEarlyRelease.ts
+++ b/integration_tests/mockApis/assessForEarlyRelease.ts
@@ -150,6 +150,21 @@ const stubGetAssessmentResponse = (assessmentId: string, assessmentResponse: _As
     },
   })
 
+const stubGetCurrentAssessmentResponse = (prisonNumber: string, assessmentResponse: _AssessmentResponse) =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: `/afer-api/support/offender/assessment/current/${prisonNumber}`,
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: assessmentResponse,
+    },
+  })
+
 const stubDeleteAssessment = (assessmentId: string) =>
   stubFor({
     request: {
@@ -1158,5 +1173,6 @@ export default {
   stubGetAssessmentSearchResponse,
   stubDeleteAssessment,
   stubGetAssessmentResponse,
+  stubGetCurrentAssessmentResponse,
   stubSaveVloAndPomInfo,
 }

--- a/integration_tests/mockApis/assessForEarlyReleaseData.ts
+++ b/integration_tests/mockApis/assessForEarlyReleaseData.ts
@@ -374,10 +374,7 @@ export const createOffenderResponse = ({
   forename = 'Bob',
   surname = 'Smith',
   dateOfBirth = '2002-02-20',
-  hdced = '2026-08-23',
-  crd = '2026-09-23',
   crn = 'DX12340A',
-  sentenceStartDate = '2028-06-23',
   createdTimestamp = '2020-01-11T12:13:00',
   lastUpdatedTimestamp = '2020-02-12T12:13:00',
 } = {}): _OffenderResponse => ({
@@ -386,10 +383,7 @@ export const createOffenderResponse = ({
   forename,
   surname,
   dateOfBirth,
-  hdced,
-  crd,
   crn,
-  sentenceStartDate,
   createdTimestamp,
   lastUpdatedTimestamp,
 })
@@ -441,6 +435,9 @@ export const createAssessmentResponse = ({
   postponementDate = '2026-08-23',
   optOutReasonType = OptOutReasonType.NOWHERE_TO_STAY,
   optOutReasonOther = 'another reason',
+  hdced = '2026-08-23',
+  crd = '2026-09-23',
+  sentenceStartDate = '2028-06-23',
 } = {}): _AssessmentResponse => ({
   id,
   bookingId,
@@ -456,4 +453,7 @@ export const createAssessmentResponse = ({
   optOutReasonType,
   optOutReasonOther,
   responsibleCom,
+  hdced,
+  crd,
+  sentenceStartDate,
 })

--- a/integration_tests/support/assessment.view.page.spec.ts
+++ b/integration_tests/support/assessment.view.page.spec.ts
@@ -39,6 +39,7 @@ test.describe('Offender assessment overview page', () => {
     await assessForEarlyRelease.stubGetOffenderResponse(prisonNumber, offender)
 
     await assessForEarlyRelease.stubGetAssessmentSearchResponse(prisonNumber, [createAssessmentSearchResponse()])
+    await assessForEarlyRelease.stubGetCurrentAssessmentResponse(prisonNumber, createAssessmentResponse())
     await page.locator('#name-button-1').click()
 
     await assessForEarlyRelease.stubGetAssessmentResponse('722', createAssessmentResponse())
@@ -52,25 +53,28 @@ test.describe('Offender assessment overview page', () => {
     const rows = page.locator('.govuk-summary-list__row')
 
     await assertKeyValue(rows, 0, `Booking Id`, `773722`)
-    await assertKeyValue(rows, 1, `Status`, `NOT_STARTED`)
-    await assertKeyValue(rows, 2, `Policy Version`, `1`)
-    await assertKeyValue(rows, 3, `Address Checks Complete`, `true`)
-    await assertKeyValue(rows, 4, `Team`, `MyTeam`)
-    await assertKeyValue(rows, 5, `Postponement Date`, `23/08/26`)
-    await assertKeyValue(rows, 6, `OptOut Reason`, `NOWHERE_TO_STAY`)
-    await assertKeyValue(rows, 7, `OptOut Reason Other`, `another reason`)
-    await assertKeyValue(rows, 8, `Assigned community officer`, `true`)
+    await assertKeyValue(rows, 1, `Sentence Start Date`, `23/06/28`)
+    await assertKeyValue(rows, 2, `HDCED`, `23/08/26`)
+    await assertKeyValue(rows, 3, `CRD`, `23/09/26`)
+    await assertKeyValue(rows, 4, `Status`, `NOT_STARTED`)
+    await assertKeyValue(rows, 5, `Policy Version`, `1`)
+    await assertKeyValue(rows, 6, `Address Checks Complete`, `true`)
+    await assertKeyValue(rows, 7, `Team`, `MyTeam`)
+    await assertKeyValue(rows, 8, `Postponement Date`, `23/08/26`)
+    await assertKeyValue(rows, 9, `OptOut Reason`, `NOWHERE_TO_STAY`)
+    await assertKeyValue(rows, 10, `OptOut Reason Other`, `another reason`)
+    await assertKeyValue(rows, 11, `Assigned community officer`, `true`)
 
     // Staff details
-    await assertKeyValue(rows, 9, `Name`, `Testforename Testsurname`)
-    await assertKeyValue(rows, 10, `Staff Code`, `STAFF1`)
-    await assertKeyValue(rows, 11, `User Name`, `testName`)
-    await assertKeyValue(rows, 12, `Email`, `test.com@moj.com`)
+    await assertKeyValue(rows, 12, `Name`, `Testforename Testsurname`)
+    await assertKeyValue(rows, 13, `Staff Code`, `STAFF1`)
+    await assertKeyValue(rows, 14, `User Name`, `testName`)
+    await assertKeyValue(rows, 15, `Email`, `test.com@moj.com`)
 
     // Audit details
-    await assertKeyValue(rows, 13, `Created`, `10/01/20 12:13`)
-    await assertKeyValue(rows, 14, `Last Updated`, `11/01/20 12:13`)
-    await assertKeyValue(rows, 15, `Deleted`, `12/01/20 12:13`)
+    await assertKeyValue(rows, 16, `Created`, `10/01/20 12:13`)
+    await assertKeyValue(rows, 17, `Last Updated`, `11/01/20 12:13`)
+    await assertKeyValue(rows, 18, `Deleted`, `12/01/20 12:13`)
   })
 
   async function assertKeyValue(rows: Locator, index: number, key: string, value: string) {

--- a/integration_tests/support/offender.view.page.spec.ts
+++ b/integration_tests/support/offender.view.page.spec.ts
@@ -4,6 +4,7 @@ import paths from '../../server/routes/paths'
 import assessForEarlyRelease from '../mockApis/assessForEarlyRelease'
 import { createStaffDetails } from '../../server/data/__testutils/testObjects'
 import {
+  createAssessmentResponse,
   createAssessmentSearchResponse,
   createOffenderResponse,
   createOffenderSearchResponse,
@@ -57,6 +58,8 @@ test.describe('Offender assessment overview page', () => {
       assessmentSearchResponse2,
     ])
 
+    await assessForEarlyRelease.stubGetCurrentAssessmentResponse(prisonNumber, createAssessmentResponse())
+
     // When
     await page.locator('#name-button-1').click()
 
@@ -79,7 +82,7 @@ test.describe('Offender assessment overview page', () => {
     await assertKeyValue(rows, 1, `Prison Number`, `A1234AE`)
     await assertKeyValue(rows, 2, `CRN`, `DX12340A`)
     await assertKeyValue(rows, 3, `DOB`, `20 Feb 2002`)
-    await assertKeyValue(rows, 4, `Sentence Start`, `23 Jun 2028`)
+    await assertKeyValue(rows, 4, `Sentence Start Date`, `23 Jun 2028`)
     await assertKeyValue(rows, 5, `HDCED`, `23 Aug 2026`)
     await assertKeyValue(rows, 6, `CRD`, `23 Sep 2026`)
     await assertKeyValue(rows, 7, `Created`, `11/01/20 12:13`)
@@ -165,6 +168,7 @@ test.describe('Offender assessment overview page', () => {
     await assessForEarlyRelease.stubGetOffenderResponse(prisonNumber, offender)
 
     await assessForEarlyRelease.stubGetAssessmentSearchResponse(prisonNumber, [createAssessmentSearchResponse()])
+    await assessForEarlyRelease.stubGetCurrentAssessmentResponse(prisonNumber, createAssessmentResponse())
     await page.locator('#name-button-1').click()
 
     const assessmentSearchResponse1 = createAssessmentSearchResponse({ deletedTimestamp: '2021-01-11T12:13:00' })

--- a/server/@types/assessForEarlyReleaseApiClientTypes.ts
+++ b/server/@types/assessForEarlyReleaseApiClientTypes.ts
@@ -13,7 +13,7 @@ export type OffenderSearchResponse = ParsingDates<_OffenderSearchResponse, 'date
 export type _OffenderResponse = components['schemas']['OffenderResponse']
 export type OffenderResponse = ParsingDates<
   _OffenderResponse,
-  'dateOfBirth' | 'hdced' | 'crd' | 'sentenceStartDate' | 'createdTimestamp' | 'lastUpdatedTimestamp'
+  'dateOfBirth' | 'createdTimestamp' | 'lastUpdatedTimestamp'
 >
 
 export type _AddressSummary = components['schemas']['AddressSummary']
@@ -91,7 +91,13 @@ export type ContactResponse = components['schemas']['ContactResponse']
 export type _AssessmentResponse = components['schemas']['AssessmentResponse']
 export type AssessmentResponse = ParsingDates<
   _AssessmentResponse,
-  'createdTimestamp' | 'lastUpdatedTimestamp' | 'deletedTimestamp' | 'postponementDate'
+  | 'createdTimestamp'
+  | 'lastUpdatedTimestamp'
+  | 'deletedTimestamp'
+  | 'postponementDate'
+  | 'hdced'
+  | 'crd'
+  | 'sentenceStartDate'
 >
 export type ComSummary = components['schemas']['ComSummary']
 export type _AssessmentSearchResponse = components['schemas']['AssessmentSearchResponse']

--- a/server/@types/assessForEarlyReleaseApiImport/index.d.ts
+++ b/server/@types/assessForEarlyReleaseApiImport/index.d.ts
@@ -939,9 +939,7 @@ export interface paths {
     trace?: never
   }
 }
-
 export type webhooks = Record<string, never>
-
 export interface components {
   schemas: {
     RetryDlqResult: {
@@ -1527,6 +1525,12 @@ export interface components {
        * @enum {string}
        */
       requestType: 'STANDARD_ADDRESS'
+    } & {
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      requestType: 'STANDARD_ADDRESS'
     }
     /** @description Request for adding a resident to a standard address check request */
     AddResidentRequest: {
@@ -1623,6 +1627,12 @@ export interface components {
        * @enum {string}
        */
       requestType: 'CAS'
+    } & {
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      requestType: 'CAS'
     }
     /** @description The request type to save a set of answers for a residential checks task. */
     SaveResidentialChecksTaskAnswersRequest: {
@@ -1685,28 +1695,10 @@ export interface components {
        */
       dateOfBirth: string
       /**
-       * Format: date
-       * @description The offender's home detention curfew eligibility date
-       * @example 2026-08-23
-       */
-      hdced: string
-      /**
-       * Format: date
-       * @description The offender's conditional release date date
-       * @example 2026-08-23
-       */
-      crd?: string
-      /**
        * @description The case reference number assigned to a person on probation in NDelius
        * @example DX12340A
        */
       crn?: string
-      /**
-       * Format: date
-       * @description The sentence start date
-       * @example 2028-06-23
-       */
-      sentenceStartDate?: string
       /**
        * Format: date-time
        * @description The create timestamp for the afer offender
@@ -1942,6 +1934,24 @@ export interface components {
       optOutReasonType?: 'NOWHERE_TO_STAY' | 'DOES_NOT_WANT_TO_BE_TAGGED' | 'NO_REASON_GIVEN' | 'OTHER'
       /** @description The opt out reason description if rhe optOutReasonType is OTHER */
       optOutReasonOther: string
+      /**
+       * Format: date
+       * @description The home detention curfew eligibility date
+       * @example 2026-08-23
+       */
+      hdced: string
+      /**
+       * Format: date
+       * @description The offender's conditional release date date
+       * @example 2026-08-23
+       */
+      crd?: string
+      /**
+       * Format: date
+       * @description The sentence start date
+       * @example 2028-06-23
+       */
+      sentenceStartDate?: string
     }
     Detail: {
       code: string
@@ -2392,19 +2402,19 @@ export interface components {
     }
     /** @description Describes a check request, a discriminator exists to distinguish between different types of check requests */
     CheckRequestSummary: {
-      requestType: string
-      /**
-       * Format: int64
-       * @description Unique internal identifier for this request
-       * @example 123344
-       */
-      requestId: number
       /**
        * @description The status of the check request
        * @example SUITABLE
        * @enum {string}
        */
       status: 'IN_PROGRESS' | 'UNSUITABLE' | 'SUITABLE'
+      /**
+       * Format: int64
+       * @description Unique internal identifier for this request
+       * @example 123344
+       */
+      requestId: number
+      requestType: string
       /**
        * @description Any additional information on the request added by the case administrator
        * @example Some additional info
@@ -2438,9 +2448,7 @@ export interface components {
   headers: never
   pathItems: never
 }
-
 export type $defs = Record<string, never>
-
 export interface operations {
   retryDlq: {
     parameters: {
@@ -4272,7 +4280,6 @@ export interface operations {
     }
   }
 }
-
 type WithRequired<T, K extends keyof T> = T & {
   [P in K]-?: T[P]
 }

--- a/server/data/aferSupportApiClient.ts
+++ b/server/data/aferSupportApiClient.ts
@@ -47,9 +47,6 @@ export default class AferSupportApiClient extends RestClient {
     return {
       ...offenderResponse,
       dateOfBirth: parseIsoDate(offenderResponse.dateOfBirth),
-      hdced: parseIsoDate(offenderResponse.hdced),
-      crd: parseIsoDate(offenderResponse.crd),
-      sentenceStartDate: parseIsoDate(offenderResponse.sentenceStartDate),
       createdTimestamp: parseIsoDateTime(offenderResponse.createdTimestamp),
       lastUpdatedTimestamp: parseIsoDateTime(offenderResponse.lastUpdatedTimestamp),
     }
@@ -68,6 +65,9 @@ export default class AferSupportApiClient extends RestClient {
       deletedTimestamp: parseIsoDateTime(currentAssessment.deletedTimestamp),
       lastUpdatedTimestamp: parseIsoDateTime(currentAssessment.lastUpdatedTimestamp),
       createdTimestamp: parseIsoDateTime(currentAssessment.createdTimestamp),
+      hdced: parseIsoDate(currentAssessment.hdced),
+      crd: parseIsoDate(currentAssessment.crd),
+      sentenceStartDate: parseIsoDate(currentAssessment.sentenceStartDate),
     }
   }
 
@@ -84,6 +84,9 @@ export default class AferSupportApiClient extends RestClient {
       deletedTimestamp: parseIsoDateTime(assessment.deletedTimestamp),
       lastUpdatedTimestamp: parseIsoDateTime(assessment.lastUpdatedTimestamp),
       createdTimestamp: parseIsoDateTime(assessment.createdTimestamp),
+      hdced: parseIsoDate(assessment.hdced),
+      crd: parseIsoDate(assessment.crd),
+      sentenceStartDate: parseIsoDate(assessment.sentenceStartDate),
     }
   }
 

--- a/server/routes/support/handlers/offenderViewHandler.ts
+++ b/server/routes/support/handlers/offenderViewHandler.ts
@@ -15,10 +15,17 @@ export default class OffenderViewHandler {
       prisonNumber,
     )
 
+    const currentAssessment = await this.supportService.getCurrentAssessment(
+      req?.middleware?.clientToken,
+      res.locals.agent,
+      prisonNumber,
+    )
+
     res.render('pages/support/offender/offenderView', {
       offender,
       assessments,
       prisonNumber,
+      currentAssessment,
     })
   }
 }

--- a/server/views/pages/support/offender/macro/assessmentDetails.njk
+++ b/server/views/pages/support/offender/macro/assessmentDetails.njk
@@ -7,6 +7,18 @@
             value: { html: params.bookingId}
         },
         {
+            key: { text: "Sentence Start Date" },
+            value: { html: params.sentenceStartDate | formatDate('dd/MM/yy') }
+        },
+        {
+            key: { text: "HDCED" },
+            value: { html: params.hdced | formatDate('dd/MM/yy') }
+        },
+        {
+            key: { text: "CRD" },
+            value: { html: params.crd | formatDate('dd/MM/yy') }
+        },
+        {
             key: { text: "Status" },
             value: { html: params.status}
         },

--- a/server/views/pages/support/offender/macro/currentAssessmentDates.njk
+++ b/server/views/pages/support/offender/macro/currentAssessmentDates.njk
@@ -1,0 +1,35 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{%  macro currentAssessmentDates(currentAssessment) %}
+    {% set dateDetails = [
+        {
+            key: { text: "Sentence Start Date" },
+            value: { html: currentAssessment.sentenceStartDate | formatDate('dd MMM yyyy') }
+        },
+        {
+            key: { text: "HDCED" },
+            value: { html: currentAssessment.hdced | formatDate('dd MMM yyyy') }
+        },
+        {
+            key: { text: "CRD" },
+            value: { html: currentAssessment.crd | formatDate('dd MMM yyyy') }
+        }
+    ]
+    %}
+
+    {% set dateDetailsNoNulls = [] %}
+    {% for dateDetail in dateDetails %}
+        {% if dateDetail.value.html %}
+            {% set dateDetailsNoNulls = (dateDetailsNoNulls.push(dateDetail), dateDetailsNoNulls) %}
+        {% endif %}
+    {% endfor %}
+
+    {{ govukSummaryList({
+            card: {
+                title: {
+                    text: "Current Assessment Dates"
+                }
+            },
+            rows: dateDetailsNoNulls
+    }) }}
+{% endmacro %}

--- a/server/views/pages/support/offender/macro/personalDetails.njk
+++ b/server/views/pages/support/offender/macro/personalDetails.njk
@@ -2,14 +2,14 @@
 
 {%  macro personalDetails(params) %}
     {% set personalDetails = [
-            {
-                key: { text: "Name" },
-                value: { text: params | toFullName }
-            },
-            {
-                key: { text: "Prison Number" },
-                value: { text: params.prisonNumber }
-            },
+        {
+            key: { text: "Name" },
+            value: { text: params | toFullName }
+        },
+        {
+            key: { text: "Prison Number" },
+            value: { text: params.prisonNumber }
+        },
         {
             key: { text: "CRN" },
             value: { text: params.crn }
@@ -17,19 +17,7 @@
         {
             key: { text: "DOB" },
             value: { html: params.dateOfBirth | formatDate('dd MMM yyyy') }
-        },
-        {
-            key: { text: "Sentence Start" },
-            value: { html: params.sentenceStartDate | formatDate('dd MMM yyyy') }
-        },
-            {
-                key: { text: "HDCED" },
-                value: { html: params.hdced | formatDate('dd MMM yyyy') }
-            },
-            {
-                key: { text: "CRD" },
-                value: { html: params.crd | formatDate('dd MMM yyyy', 'not found')}
-            }
+        }
     ]
     %}
 

--- a/server/views/pages/support/offender/offenderView.njk
+++ b/server/views/pages/support/offender/offenderView.njk
@@ -8,6 +8,7 @@
 {% from "govuk/components/tabs/macro.njk" import govukTabs %}
 {% from "moj/components/banner/macro.njk" import mojBanner %}
 {% from "./macro/assessmentsList.njk" import assessmentsList %}
+{% from "./macro/currentAssessmentDates.njk" import currentAssessmentDates %}
 
 {% set pageTitle = "Application overview - " + applicationName %}
 
@@ -18,7 +19,8 @@
         </div>
         <div class="govuk-grid-column-full">
             <div class="govuk-grid-column-one-half">
-                {{ personalDetails(offender) }}
+                {{ personalDetails(offender, currentAssessment) }}
+                {{ currentAssessmentDates(currentAssessment) }}
             </div>
             <div class="govuk-grid-column-one-half">
                 {{ auditDetails(offender) }}


### PR DESCRIPTION
This PR is to move some key offender dates from off the offender entity and onto the assessment as they will vary per booking/assessment rather than related directly to offender.

Changes:
![Screenshot 2025-05-01 at 17 49 08](https://github.com/user-attachments/assets/7e109a88-eb06-4985-9d11-524b27f8dcad)

![Screenshot 2025-05-01 at 17 49 13](https://github.com/user-attachments/assets/088c9f34-9fe0-4269-8678-acce5f51ef7b)

