### PR TITLE
CVSL-2723 change route to get current assessment

### DIFF
--- a/integration_tests/mockApis/assessForEarlyRelease.ts
+++ b/integration_tests/mockApis/assessForEarlyRelease.ts
@@ -154,7 +154,7 @@ const stubGetCurrentAssessmentResponse = (prisonNumber: string, assessmentRespon
   stubFor({
     request: {
       method: 'GET',
-      urlPattern: `/afer-api/support/offender/assessment/current/${prisonNumber}`,
+      urlPattern: `/afer-api/support/offender/${prisonNumber}/assessment/current`,
     },
     response: {
       status: 200,

--- a/server/data/aferSupportApiClient.ts
+++ b/server/data/aferSupportApiClient.ts
@@ -54,7 +54,7 @@ export default class AferSupportApiClient extends RestClient {
 
   async getCurrentAssessment(token: string, agent: Agent, prisonNumber: string): Promise<AssessmentResponse> {
     const currentAssessment = await this.getWithToken<_AssessmentResponse>(
-      `/support/offender/assessment/current/${prisonNumber}`,
+      `support/offender/${prisonNumber}/assessment/current`,
       token,
       agent,
     )


### PR DESCRIPTION
This PR is to adjust some test data to include default values and adjust the route to get the current assessment for support. 